### PR TITLE
Fix payment details

### DIFF
--- a/app/models/solidus_paypal_braintree/source.rb
+++ b/app/models/solidus_paypal_braintree/source.rb
@@ -90,7 +90,7 @@ module SolidusPaypalBraintree
         card_type: payment_details_returned.card_type,
         cardholder_name: payment_details_returned.cardholder_name
       )
-      self.payment_details.save!
+      self.save!
       self.payment_details
     end
 

--- a/db/migrate/20181015212440_add_payment_details_to_source.rb
+++ b/db/migrate/20181015212440_add_payment_details_to_source.rb
@@ -1,4 +1,4 @@
-class AddBraintreePaymentMethodToSource < SolidusSupport::Migration[4.2]
+class AddPaymentDetailsToSource < SolidusSupport::Migration[4.2]
   def up
     change_table :solidus_paypal_braintree_sources do |t|
       t.references :payment_details, polymorphic: true

--- a/spec/models/solidus_paypal_braintree/source_spec.rb
+++ b/spec/models/solidus_paypal_braintree/source_spec.rb
@@ -353,7 +353,11 @@ RSpec.describe SolidusPaypalBraintree::Source, type: :model do
 
       context 'when last_digits is accessed multiple times' do
         include_context 'credit card created'
-        subject { 2.times.collect { payment_source.last_digits }.last }
+        subject do
+          payment_source.last_digits
+          payment_source.reload
+          payment_source.last_digits
+        end
 
         it 'ensures that braintree gateway is called just once' do
           expect(payment_method_gateway).to receive(:find).once


### PR DESCRIPTION
There was a bug in the save that the relation was not getting
saved. The test did not catch this bug because the object
was not getting reloaded and it was using in memory record.

Also We fixed the name of the migration in the main code base
but fix is also required in the gem for any future user.