### PR TITLE
Map store to merchant account

### DIFF
--- a/app/models/solidus_paypal_braintree/gateway.rb
+++ b/app/models/solidus_paypal_braintree/gateway.rb
@@ -35,7 +35,7 @@ module SolidusPaypalBraintree
     preference(:merchant_id, :string, default: nil)
     preference(:public_key,  :string, default: nil)
     preference(:private_key, :string, default: nil)
-    preference(:merchant_currency_map, :hash, default: {})
+    preference(:store_merchant_map, :hash, default: {})
     preference(:paypal_payee_email_map, :hash, default: {})
 
     def partial_name
@@ -349,14 +349,16 @@ module SolidusPaypalBraintree
     end
 
     def merchant_account_for(_source, options)
-      if options[:currency]
-        preferred_merchant_currency_map[options[:currency]]
+      store_code = options[:store_code]
+
+      if store_code
+        preferred_store_merchant_map[store_code]
       end
     end
 
     def paypal_payee_email_for(source, options)
       if source.paypal?
-        preferred_paypal_payee_email_map[options[:currency]]
+        preferred_paypal_payee_email_map[options[:store_code]]
       end
     end
 
@@ -369,7 +371,7 @@ module SolidusPaypalBraintree
 
       merchant_account_id = merchant_account_for(
         payment.source,
-        { currency: payment.currency }
+        { store_code: payment.order.store.code }
       )
       if merchant_account_id
         params[:credit_card] ||= {}

--- a/spec/models/solidus_paypal_braintree/gateway_spec.rb
+++ b/spec/models/solidus_paypal_braintree/gateway_spec.rb
@@ -28,21 +28,21 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
     context "with valid hash syntax" do
       let(:update_params) do
         {
-          preferred_merchant_currency_map: '{"EUR" => "test_merchant_account_id"}',
+          preferred_store_merchant_map: '{"store" => "test_merchant_account_id"}',
           preferred_paypal_payee_email_map: '{"CAD" => "bruce+wayne@example.com"}'
         }
       end
 
       it "successfully updates the preference" do
         subject
-        expect(gateway.preferred_merchant_currency_map).to eq({ "EUR" => "test_merchant_account_id" })
+        expect(gateway.preferred_store_merchant_map).to eq({ "store" => "test_merchant_account_id" })
         expect(gateway.preferred_paypal_payee_email_map).to eq({ "CAD" => "bruce+wayne@example.com" })
       end
     end
 
     context "with invalid user input" do
       let(:update_params) do
-        { preferred_merchant_currency_map: '{this_is_not_a_valid_hash}' }
+        { preferred_store_merchant_map: '{this_is_not_a_valid_hash}' }
       end
 
       it "raise a JSON parser error" do
@@ -200,17 +200,21 @@ RSpec.describe SolidusPaypalBraintree::Gateway do
         end
       end
 
-      context 'different merchant account for currency', vcr: { cassette_name: 'gateway/authorize/merchant_account/EUR' } do
-        let(:currency) { 'EUR' }
+      context 'different merchant account for store', vcr: { cassette_name: 'gateway/authorize/merchant_account/EUR' } do
+        before do
+          gateway_options.merge!(store_code: "stembolt-eu")
+        end
 
-        it 'settles with the correct currency' do
+        it 'settles with the correct merchant' do
           transaction = braintree.transaction.find(authorize.authorization)
           expect(transaction.merchant_account_id).to eq 'stembolt_EUR'
         end
       end
 
-      context 'different paypal payee email for currency', vcr: { cassette_name: 'gateway/authorize/paypal/EUR' } do
-        let(:currency) { 'EUR' }
+      context 'different paypal payee email for store code', vcr: { cassette_name: 'gateway/authorize/paypal/EUR' } do
+        before do
+          gateway_options.merge!(store_code: "stembolt-eu")
+        end
 
         it 'uses the correct payee email' do
           expect_any_instance_of(Braintree::TransactionGateway).

--- a/spec/support/gateway_helpers.rb
+++ b/spec/support/gateway_helpers.rb
@@ -7,11 +7,11 @@ module SolidusPaypalBraintree::GatewayHelpers
         public_key:  'mwjkkxwcp32ckhnf',
         private_key: 'a9298f43b30c699db3072cc4a00f7f49',
         merchant_id: '7rdg92j7bm7fk5h3',
-        merchant_currency_map: {
-          'EUR' => 'stembolt_EUR'
+        store_merchant_map: {
+          'stembolt-eu' => 'stembolt_EUR'
         },
         paypal_payee_email_map: {
-          'EUR' => 'paypal+europe@example.com'
+          'stembolt-eu' => 'paypal+europe@example.com'
         }
       }
     }.merge(opts))


### PR DESCRIPTION
When processing payments in international stores we want to
associate the payments with a merchant account. This allows
transactions isolated by store and makes the record keeping
process easier.

Previously, merchant accounts were mapped to a currency. However,
this does not work for business which operate in multiple countries
that share a currency (ie. the Euro zone). To make it possible to
have multiple merchant accounts per currency, we change the association
from currency to merchant account to store code to merchant account.